### PR TITLE
Add currency API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,11 @@
-# The directory Mix will write compiled artifacts to.
-/_build/
-
-# If you run "mix test --cover", coverage assets end up here.
-/cover/
-
-# The directory Mix downloads your dependencies sources to.
-/deps/
-
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc/
-
-# Ignore .fetch files in case you like to edit your project deps locally.
+/_build
+/cover
+/deps
+/doc
 /.fetch
-
-# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
-
-# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-
-# Ignore package tarball (built via "mix hex.build").
+*.beam
+/config/*.secret.exs
+.elixir_ls/
 currency_converter-*.tar
-
-# Since we are building assets from assets/,
-# we ignore priv/static. You may want to comment
-# this depending on your deployment strategy.
-/priv/static/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 To start your Phoenix server:
 
+  * Install Elixir
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
   * Start Phoenix endpoint with `mix phx.server`
@@ -9,6 +10,111 @@ To start your Phoenix server:
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+
+## Usage
+
+### Currencies
+
+#### Create a currency
+
+To create a new currency send a JSON post to the currencies endpoint with currency as the body and the name and short code of the currency you want to add.
+
+```sh
+curl -X POST \
+  http://localhost:4000/api/currencies \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -d '{
+	"currency": {
+		"name": "Euros",
+		"code": "EUR"
+	}
+}'
+```
+
+response:
+```json
+  {
+      "data": {
+          "code": "EUR",
+          "id": "db89e438-edc2-46af-b0bf-f004ec671588",
+          "name": "Euros"
+      }
+  }
+```
+
+### Update a currency
+
+To update submit a patch or put to the specific currency endpoint and sned across the field(s) you want to change as part of the currency body
+
+```sh
+curl -X PATCH \
+  http://localhost:4000/api/currencies/db89e438-edc2-46af-b0bf-f004ec671588 \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -d '{
+	"currency": {
+		"code": "USD"
+	}
+}'
+```
+
+response:
+```json
+  {
+      "data": {
+          "code": "EUR",
+          "id": "db89e438-edc2-46af-b0bf-f004ec671588",
+          "name": "USD"
+      }
+  }
+```
+
+#### List Currencies
+
+Submitting a get request to the currencies endpoint will provide an index of all currencies
+
+```sh
+curl -X GET \
+  http://localhost:4000/api/currencies \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json'
+```
+
+response:
+```json
+{
+    "data": [
+        {
+            "code": "GBP",
+            "id": "14376d5e-5ec1-47bd-866a-6de1f2cfb0e8",
+            "name": "Pounds Sterling"
+        }
+    ]
+}
+```
+
+#### Show Currency
+
+Submitting a get request to the currencies endpoint with the ID of a specific currency will returns it's details
+
+```sh
+curl -X GET \
+  http://localhost:4000/api/currencies/14376d5e-5ec1-47bd-866a-6de1f2cfb0e8 \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json'
+```
+
+response:
+```json
+{
+    "data": {
+        "code": "GBP",
+        "id": "14376d5e-5ec1-47bd-866a-6de1f2cfb0e8",
+        "name": "Pounds Sterling"
+    }
+}
+```
 
 ## Learn more
 

--- a/lib/currency_converter/directory.ex
+++ b/lib/currency_converter/directory.ex
@@ -1,0 +1,104 @@
+defmodule CurrencyConverter.Directory do
+  @moduledoc """
+  The Directory context.
+  """
+
+  import Ecto.Query, warn: false
+  alias CurrencyConverter.Repo
+
+  alias CurrencyConverter.Directory.Currency
+
+  @doc """
+  Returns the list of currencies.
+
+  ## Examples
+
+      iex> list_currencies()
+      [%Currency{}, ...]
+
+  """
+  def list_currencies do
+    Repo.all(Currency)
+  end
+
+  @doc """
+  Gets a single currency.
+
+  Raises `Ecto.NoResultsError` if the Currency does not exist.
+
+  ## Examples
+
+      iex> get_currency!(123)
+      %Currency{}
+
+      iex> get_currency!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_currency!(id), do: Repo.get!(Currency, id)
+
+  @doc """
+  Creates a currency.
+
+  ## Examples
+
+      iex> create_currency(%{field: value})
+      {:ok, %Currency{}}
+
+      iex> create_currency(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_currency(attrs \\ %{}) do
+    %Currency{}
+    |> Currency.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a currency.
+
+  ## Examples
+
+      iex> update_currency(currency, %{field: new_value})
+      {:ok, %Currency{}}
+
+      iex> update_currency(currency, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_currency(%Currency{} = currency, attrs) do
+    currency
+    |> Currency.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a currency.
+
+  ## Examples
+
+      iex> delete_currency(currency)
+      {:ok, %Currency{}}
+
+      iex> delete_currency(currency)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_currency(%Currency{} = currency) do
+    Repo.delete(currency)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking currency changes.
+
+  ## Examples
+
+      iex> change_currency(currency)
+      %Ecto.Changeset{source: %Currency{}}
+
+  """
+  def change_currency(%Currency{} = currency) do
+    Currency.changeset(currency, %{})
+  end
+end

--- a/lib/currency_converter/directory/currency.ex
+++ b/lib/currency_converter/directory/currency.ex
@@ -1,0 +1,21 @@
+defmodule CurrencyConverter.Directory.Currency do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "currencies" do
+    field :code, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(currency, attrs) do
+    currency
+    |> cast(attrs, [:name, :code])
+    |> validate_required([:name, :code])
+    |> unique_constraint(:code, [])
+  end
+end

--- a/lib/currency_converter_web/controllers/currency_controller.ex
+++ b/lib/currency_converter_web/controllers/currency_controller.ex
@@ -1,0 +1,43 @@
+defmodule CurrencyConverterWeb.CurrencyController do
+  use CurrencyConverterWeb, :controller
+
+  alias CurrencyConverter.Directory
+  alias CurrencyConverter.Directory.Currency
+
+  action_fallback CurrencyConverterWeb.FallbackController
+
+  def index(conn, _params) do
+    currencies = Directory.list_currencies()
+    render(conn, "index.json", currencies: currencies)
+  end
+
+  def create(conn, %{"currency" => currency_params}) do
+    with {:ok, %Currency{} = currency} <- Directory.create_currency(currency_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.currency_path(conn, :show, currency))
+      |> render("show.json", currency: currency)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    currency = Directory.get_currency!(id)
+    render(conn, "show.json", currency: currency)
+  end
+
+  def update(conn, %{"id" => id, "currency" => currency_params}) do
+    currency = Directory.get_currency!(id)
+
+    with {:ok, %Currency{} = currency} <- Directory.update_currency(currency, currency_params) do
+      render(conn, "show.json", currency: currency)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    currency = Directory.get_currency!(id)
+
+    with {:ok, %Currency{}} <- Directory.delete_currency(currency) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/currency_converter_web/controllers/fallback_controller.ex
+++ b/lib/currency_converter_web/controllers/fallback_controller.ex
@@ -1,0 +1,22 @@
+defmodule CurrencyConverterWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use CurrencyConverterWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(CurrencyConverterWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(CurrencyConverterWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/lib/currency_converter_web/router.ex
+++ b/lib/currency_converter_web/router.ex
@@ -7,6 +7,6 @@ defmodule CurrencyConverterWeb.Router do
 
   scope "/api", CurrencyConverterWeb do
     pipe_through :api
-    resources "/currencies", CurrencyController
+    resources "/currencies", CurrencyController, except: [:new, :edit]
   end
 end

--- a/lib/currency_converter_web/router.ex
+++ b/lib/currency_converter_web/router.ex
@@ -7,5 +7,6 @@ defmodule CurrencyConverterWeb.Router do
 
   scope "/api", CurrencyConverterWeb do
     pipe_through :api
+    resources "/currencies", CurrencyController
   end
 end

--- a/lib/currency_converter_web/views/changeset_view.ex
+++ b/lib/currency_converter_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule CurrencyConverterWeb.ChangesetView do
+  use CurrencyConverterWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `CurrencyConverterWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/lib/currency_converter_web/views/currency_view.ex
+++ b/lib/currency_converter_web/views/currency_view.ex
@@ -1,0 +1,18 @@
+defmodule CurrencyConverterWeb.CurrencyView do
+  use CurrencyConverterWeb, :view
+  alias CurrencyConverterWeb.CurrencyView
+
+  def render("index.json", %{currencies: currencies}) do
+    %{data: render_many(currencies, CurrencyView, "currency.json")}
+  end
+
+  def render("show.json", %{currency: currency}) do
+    %{data: render_one(currency, CurrencyView, "currency.json")}
+  end
+
+  def render("currency.json", %{currency: currency}) do
+    %{id: currency.id,
+      name: currency.name,
+      code: currency.code}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule CurrencyConverter.MixProject do
       {:jason, "~> 1.0"},
       {:plug_cowboy, "~> 2.0"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
-      {:ex_unit_notifier, "~> 0.1", only: :test}
+      {:ex_unit_notifier, "~> 0.1", only: :test},
+      {:credo, "~> 1.1.0", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,8 @@ defmodule CurrencyConverter.MixProject do
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
       {:plug_cowboy, "~> 2.0"},
-      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
+      {:ex_unit_notifier, "~> 0.1", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "3.3.2", "002aa428c752a8ee4bb65baa9d1041f0514d7435d2e21d58cb6aa69a1076721d", [:mix], [{:decimal, "~> 1.6 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ecto_sql": {:hex, :ecto_sql, "3.3.3", "7d8962d39f16181c1df1bbd0f64aa392bd9ce0b9f8ff5ff21d43dca3d624eee7", [:mix], [{:db_connection, "~> 2.2", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.4 or ~> 3.3.2", [hex: :ecto, repo: "hexpm", optional: false]}, {:myxql, "~> 0.3.0", [hex: :myxql, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.15.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_unit_notifier": {:hex, :ex_unit_notifier, "0.1.4", "36a2dcab829f506e01bf17816590680dd1474407926d43e64c1263e627c364b8", [:mix], [], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.17.4", "f13088e1ec10ce01665cf25f5ff779e7df3f2dc71b37084976cf89d1aa124d5c", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.8.0", "fd0ff1787db84ac415b8211573e9a30a3ebe71b5cbff7f720089972b2319c8a4", [:rebar3], [], "hexpm"},
+  "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.2.0", "e923e88887cd60f9891fd324ac5e0290954511d090553c415fbf54be4c57ee63", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "3.3.2", "002aa428c752a8ee4bb65baa9d1041f0514d7435d2e21d58cb6aa69a1076721d", [:mix], [{:decimal, "~> 1.6 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},

--- a/priv/repo/migrations/20200203091522_create_currencies.exs
+++ b/priv/repo/migrations/20200203091522_create_currencies.exs
@@ -1,0 +1,15 @@
+defmodule CurrencyConverter.Repo.Migrations.CreateCurrencies do
+  use Ecto.Migration
+
+  def change do
+    create table(:currencies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :code, :string
+
+      timestamps()
+    end
+
+    create index(:currencies, :code, unique: true)
+  end
+end

--- a/test/currency_converter/directory_test.exs
+++ b/test/currency_converter/directory_test.exs
@@ -1,0 +1,71 @@
+defmodule CurrencyConverter.DirectoryTest do
+  use CurrencyConverter.DataCase
+
+  alias CurrencyConverter.Directory
+
+  describe "currencies" do
+    alias CurrencyConverter.Directory.Currency
+
+    @valid_attrs %{code: "EUR", name: "Euros"}
+    @update_attrs %{code: "USD", name: "US Dollars"}
+    @invalid_attrs %{code: nil, name: nil}
+
+    def currency_fixture(attrs \\ %{}) do
+      {:ok, currency} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Directory.create_currency()
+
+      currency
+    end
+
+    test "list_currencies/0 returns all currencies" do
+      currency = currency_fixture()
+      assert Directory.list_currencies() == [currency]
+    end
+
+    test "get_currency!/1 returns the currency with given id" do
+      currency = currency_fixture()
+      assert Directory.get_currency!(currency.id) == currency
+    end
+
+    test "create_currency/1 with valid data creates a currency" do
+      assert {:ok, %Currency{} = currency} = Directory.create_currency(@valid_attrs)
+      assert currency.code == "EUR"
+      assert currency.name == "Euros"
+    end
+
+    test "create_currency/1 with duplicate data returns error changeset" do
+      _currency = currency_fixture()
+      assert {:error, %Ecto.Changeset{}} = Directory.create_currency(@valid_attrs)
+    end
+
+    test "create_currency/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Directory.create_currency(@invalid_attrs)
+    end
+
+    test "update_currency/2 with valid data updates the currency" do
+      currency = currency_fixture()
+      assert {:ok, %Currency{} = currency} = Directory.update_currency(currency, @update_attrs)
+      assert currency.code == "USD"
+      assert currency.name == "US Dollars"
+    end
+
+    test "update_currency/2 with invalid data returns error changeset" do
+      currency = currency_fixture()
+      assert {:error, %Ecto.Changeset{}} = Directory.update_currency(currency, @invalid_attrs)
+      assert currency == Directory.get_currency!(currency.id)
+    end
+
+    test "delete_currency/1 deletes the currency" do
+      currency = currency_fixture()
+      assert {:ok, %Currency{}} = Directory.delete_currency(currency)
+      assert_raise Ecto.NoResultsError, fn -> Directory.get_currency!(currency.id) end
+    end
+
+    test "change_currency/1 returns a currency changeset" do
+      currency = currency_fixture()
+      assert %Ecto.Changeset{} = Directory.change_currency(currency)
+    end
+  end
+end

--- a/test/currency_converter_web/controllers/currency_controller_test.exs
+++ b/test/currency_converter_web/controllers/currency_controller_test.exs
@@ -1,0 +1,108 @@
+defmodule CurrencyConverterWeb.CurrencyControllerTest do
+  use CurrencyConverterWeb.ConnCase
+
+  alias CurrencyConverter.Directory
+  alias CurrencyConverter.Directory.Currency
+
+  @create_attrs %{
+    code: "USD",
+    name: "US Dollars"
+  }
+  @update_attrs %{
+    code: "GBP",
+    name: "Great British Pounds"
+  }
+  @invalid_attrs %{code: nil, name: nil}
+
+  def fixture(:currency) do
+    {:ok, currency} = Directory.create_currency(@create_attrs)
+    currency
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    setup [:create_currency]
+
+    test "lists all currencies", %{conn: conn} do
+      conn = get(conn, Routes.currency_path(conn, :index))
+      assert is_list(json_response(conn, 200)["data"])
+    end
+  end
+
+  describe "create currency" do
+    test "renders currency when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.currency_path(conn, :create), currency: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.currency_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "code" => "USD",
+               "name" => "US Dollars"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.currency_path(conn, :create), currency: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "create currency with duplicate data" do
+    setup [:create_currency]
+
+    @attrs_with_dup %{
+      code: "USD",
+      name: "US Dollars 2"
+    }
+
+    test "renders errors when duplicate code is submitted", %{conn: conn} do
+      conn = post(conn, Routes.currency_path(conn, :create), currency: @attrs_with_dup)
+      assert json_response(conn, 422)
+    end
+  end
+
+
+  describe "update currency" do
+    setup [:create_currency]
+    test "renders currency when data is valid", %{conn: conn, currency: %Currency{id: id} = currency} do
+      conn = put(conn, Routes.currency_path(conn, :update, currency), currency: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.currency_path(conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "code" => "GBP",
+               "name" => "Great British Pounds"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, currency: currency} do
+      conn = put(conn, Routes.currency_path(conn, :update, currency), currency: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete currency" do
+    setup [:create_currency]
+
+    test "deletes chosen currency", %{conn: conn, currency: currency} do
+      conn = delete(conn, Routes.currency_path(conn, :delete, currency))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.currency_path(conn, :show, currency))
+      end
+    end
+  end
+
+  defp create_currency(_) do
+    currency = fixture(:currency)
+    {:ok, currency: currency}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
+ExUnit.configure formatters: [ExUnit.CLIFormatter, ExUnitNotifier]
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(CurrencyConverter.Repo, :manual)


### PR DESCRIPTION
We need admins to be able to handle the creation and updating
of currencies if we want to use them later in the process.

This adds a basic API for managing the currencies.